### PR TITLE
Using Adhoc Rules to compile on MacOS

### DIFF
--- a/UPSTREAM.README.md
+++ b/UPSTREAM.README.md
@@ -1,0 +1,1 @@
+upstream/README.md

--- a/glfw-examples/buildfile
+++ b/glfw-examples/buildfile
@@ -13,7 +13,7 @@ for n: boing gears heightmap offscreen particles \
 exe{particles}: libue{tinycthread} libue{getopt}
 
 c.poptions += "-I$src_root/deps/"
-./: manifest doc{LICENSE.md}
+./: manifest legal{LICENSE.md}
 exe{*}: install = false
 
 if ($c.target.class == 'windows')

--- a/glfw-tests/buildfile
+++ b/glfw-tests/buildfile
@@ -1,1 +1,1 @@
-./: {*/ -build/ -basics/} manifest doc{LICENSE.md}
+./: {*/ -build/ -basics/} manifest legal{LICENSE.md}

--- a/glfw/build/root.build
+++ b/glfw/build/root.build
@@ -1,6 +1,5 @@
 c.std = 99
 
-using cc
 using c
 using in
 
@@ -11,8 +10,8 @@ h{*}: extension = h
 #
 test.target = $c.target
 
-tcls = $cc.target.class
-tsys = $cc.target.system
+tcls = $c.target.class
+tsys = $c.target.system
 
 config [bool] config.glfw.usewayland ?= false
 config [bool] config.glfw.useosmesa ?= false

--- a/glfw/buildfile
+++ b/glfw/buildfile
@@ -1,4 +1,4 @@
-./: {*/ -build/ -upstream/} doc{README.md LICENSE.md} manifest
+./: {*/ -build/ -upstream/} doc{README.md} legal{LICENSE.md} manifest
 
 # Don't install tests.
 #

--- a/glfw/manifest
+++ b/glfw/manifest
@@ -11,5 +11,6 @@ tests: glfw-tests == $
 examples: glfw-examples == $
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
+builds: gcc : -macos ; GCC on macos not supported -> GCC cannot parse cocoa
 requires: ; OpengGL/Vulkan libraries. Usually installed with system or SDK on Windows.
 requires: ; X11 when building for Linux

--- a/glfw/manifest
+++ b/glfw/manifest
@@ -11,7 +11,7 @@ tests: glfw-tests == $
 examples: glfw-examples == $
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
-builds: default
+builds: -freebsd
 build-exclude: macos*-gcc** ; GCC not supported on macos -> Cannot parse Cocoa
 requires: ; OpengGL/Vulkan libraries. Usually installed with system or SDK on Windows.
 requires: ; X11 when building for Linux

--- a/glfw/manifest
+++ b/glfw/manifest
@@ -3,7 +3,7 @@ name: glfw
 version: 3.3.4-a.0.z
 summary: GLFW is an Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development. It provides a simple, platform-independent API for creating windows, contexts and surfaces, reading input, handling events, etc.
 license: Zlib
-description-file: ../UPSTREAM.README.md
+description-file: README.md
 url: https://www.glfw.org
 package-url: https://github.com/Swat-SomeBug/glfw.git
 email: swat.somebug@gmail.com
@@ -11,6 +11,7 @@ tests: glfw-tests == $
 examples: glfw-examples == $
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
-builds: gcc : -macos ; GCC on macos not supported -> GCC cannot parse cocoa
+builds: default
+build-exclude: macos*-gcc** ; GCC not supported on macos -> Cannot parse Cocoa
 requires: ; OpengGL/Vulkan libraries. Usually installed with system or SDK on Windows.
 requires: ; X11 when building for Linux

--- a/glfw/src/buildfile
+++ b/glfw/src/buildfile
@@ -88,7 +88,8 @@ elif ($cocoa)
     case "*clang*"
       c.coptions += -objC
     default
-      c.libs += -lobjc
+      fail "Only clang supported on macos"
+  
   }
   c.poptions += -D_GLFW_COCOA
   gl_libs += -framework Cocoa -framework IOKit -framework CoreFoundation

--- a/glfw/src/buildfile
+++ b/glfw/src/buildfile
@@ -1,24 +1,48 @@
 # Public headers.
 #
 
-define objectivec: c
-objectivec{*}: extension = m
-
 pub = [dir_path] ../include/GLFW/
 
 include $pub
 
 pub_hdrs = $($pub/pub_hdrs)
 cmn_hdrs = h{internal mappings}
-cmn_srcs = c{context init \
-             input monitor \
-             vulkan window}             
+cmn_srcs = context.c init.c \
+           input.c monitor.c \
+           vulkan.c window.c             
 
-lib{glfw}: $cmn_hdrs $pub_hdrs $cmn_srcs
+lib{glfw}: $cmn_hdrs $pub_hdrs c{$cmn_srcs}: include = ($cocoa == false)
 
 # Macos
-lib{glfw}: {h objectivec}{cocoa* nsgl_context}: include = $cocoa
-lib{glfw}: {h c}{posix_* egl_context osmesa_context}: include = $cocoa
+# Using adhoc receipes to compile all sources as objective-C files
+# Extensions for files used in variable to allow wildcard filtering
+# Otherwise both header and source code is matched
+#
+cocoa_files = cocoa_*.m nsgl_context.m $cmn_srcs \
+              posix_thread.c cocoa_time.c \
+              egl_context.c osmesa_context.c
+for cocoa_file: $cocoa_files
+{
+  n = $name($cocoa_file)
+  obja{"$n".a.o}: file{"$cocoa_file"}
+  {{
+     diag objective-c ($<[0])
+     $c.path $c.poptions $cc.poptions $c.coptions $cc.coptions\
+     -c $path($<[0]) -o $path($>)
+  }}
+  objs{"$n".dylib.o}: file{"$cocoa_file"}
+  {{
+     diag objective-c ($<[0])
+     $c.path $c.poptions $cc.poptions $c.coptions $cc.coptions\
+     -c $path($<[0]) -o $path($>)
+  }}
+
+  liba{glfw}: obja{"$n".a.o}: include = $cocoa
+  libs{glfw}: objs{"$n".dylib.o}: include = $cocoa
+}
+
+lib{glfw}: h{cocoa* nsgl_context osmesa_context\
+             egl_context posix_thread}: include = $cocoa
 
 # Windows
 lib{glfw}: {h c}{win32* ?gl_context osmesa_context}: include = $win32
@@ -59,15 +83,15 @@ if ($win32)
 }
 elif ($cocoa)
 {
-  switch $cxx.id
+  switch $cxx.id: path.match
   {
-    case '*clang*'
+    case "*clang*"
       c.coptions += -objC
     default
       c.libs += -lobjc
   }
   c.poptions += -D_GLFW_COCOA
-  gl_libs += -framework Cocoa -framework IOKit -framework CoreFoundations
+  gl_libs += -framework Cocoa -framework IOKit -framework CoreFoundation
 }
 elif ($usewayland)
   c.poptions += -D_GLFW_WAYLAND

--- a/glfw/src/buildfile
+++ b/glfw/src/buildfile
@@ -83,7 +83,7 @@ if ($win32)
 }
 elif ($cocoa)
 {
-  switch $cxx.id: path.match
+  switch $c.id: path.match
   {
     case "*clang*"
       c.coptions += -objC


### PR DESCRIPTION
Adding adhoc rules for objective-C compilation on MacOS. Does not effect other platforms.