### PR TITLE
Remove regex check in monitors.testscript

### DIFF
--- a/glfw-tests/console/buildfile
+++ b/glfw-tests/console/buildfile
@@ -9,10 +9,7 @@ for n: clipboard events msaa glfwinfo \
   
 exe{glfwinfo}: ../deps/liba{glad_vulkan}
 exe{glfwinfo}: testscript{glfwinfo}
-
-# Disable monitors test when osmesa is used
-glfw_usesosmesa = $($libs: config.glfw.useosmesa)
-exe{monitors}: testscript{monitors} : include = (!$glfw_usesosmesa)
+exe{monitors}: testscript{monitors}
   
 if ($c.target.class == 'windows')
   c.poptions += -D_CRT_SECURE_NO_WARNINGS

--- a/glfw-tests/console/monitors.testscript
+++ b/glfw-tests/console/monitors.testscript
@@ -1,3 +1,8 @@
 : MONITORS
 $* >- == 0
 
+: MONITORS-USAGE
+$* -h >>EOM
+Usage: monitors [-t]
+       monitors -h
+EOM

--- a/glfw-tests/console/monitors.testscript
+++ b/glfw-tests/console/monitors.testscript
@@ -1,14 +1,3 @@
 : MONITORS
-$* >>~%EOM%
-%Name\:.+%
-%Current mode\:.+%
-%Virtual position\:.+%
-%Content scale\:.+%
-%Physical size\:.+%
-%Monitor work area\:.+%
-%Modes\:.*%
-%(
-%.*%
-%)*?
-EOM
+$* >- == 0
 


### PR DESCRIPTION
 - Allows running on machines with no monitors attached.
 - Important is to not have any error returned with this test
 - No need to selectively disable exe{monitors}/monitors.testscript for
    osmesa

Fixes #5 