### PR TITLE
Change c.std value to standard c99

### DIFF
--- a/glfw/build/root.build
+++ b/glfw/build/root.build
@@ -1,4 +1,4 @@
-c.std = gnu99
+c.std = 99
 
 using c
 using in


### PR DESCRIPTION
Closes https://github.com/build2-packaging/glfw/issues/10

Looking at the source, they use proper #define to manage with and/or without GNU extension

[CI](https://ci.stage.build2.org/@be009839-7f05-4341-b7d1-fd0e924b32bc?builds=&pv=&th=*&tg=&tc=&pc=&rs=*)